### PR TITLE
Adding support for the new Shaman totembars

### DIFF
--- a/Mangosbot.lua
+++ b/Mangosbot.lua
@@ -1374,33 +1374,26 @@ function CreateSelectedBotPanel()
             tooltip = "Use melee AOE abilities",
             index = 4
         },
-        ["totems"] = {
-            icon = "totems",
-            command = {[0] = "co ~totems,?"},
-            strategy = "totems",
-            tooltip = "Use totems",
-            index = 5
-        },
         ["bmana"] = {
             icon = "bmana",
             command = {[0] = "co ~bmana,?", [1] = "nc ~bmana,?"},
             strategy = "bmana",
             tooltip = "Buff mana regen",
-            index = 6
+            index = 5
         },
         ["bdps"] = {
             icon = "bdps",
             command = {[0] = "co ~bdps,?", [1] = "nc ~bdps,?"},
             strategy = "bdps",
             tooltip = "Buff DPS",
-            index = 7
+            index = 6
         },
         ["cure"] = {
             icon = "cure",
             command = {[0] = "co ~cure,?", [1] = "nc ~cure,?"},
             strategy = "cure",
             tooltip = "Cure (poison, disease, etc.)",
-            index = 8
+            index = 7
         }
     })
     CreateToolBar(frame, -y, "CLASS_WARLOCK", {
@@ -1472,6 +1465,37 @@ function CreateSelectedBotPanel()
     })
     
     y = y + 25
+    CreateToolBar(frame, -y, "CLASS_SHAMAN_TOTEMS", {
+        ["totems"] = {
+            icon = "totems",
+            command = {[0] = "co ~totems,?"},
+            strategy = "totems",
+            tooltip = "Default totems",
+            index = 0
+        },
+        ["totembar_elements"] = {
+            icon = "totems",
+            command = {[0] = "co ~totembar elements,?"},
+            strategy = "totembar elements",
+            tooltip = "Call of Elements totembar",
+            index = 1
+        },
+        ["totembar_ancestors"] = {
+            icon = "totems",
+            command = {[0] = "co ~totembar ancestors,?"},
+            strategy = "totembar ancestors",
+            tooltip = "Call of Ancestors totembar",
+            index = 2
+        },
+        ["totembarElements"] = {
+            icon = "totems",
+            command = {[0] = "co ~totembar spirits,?"},
+            strategy = "totembar spirits",
+            tooltip = "Call of Spirits totembar",
+            index = 3
+        }                
+    })
+    
     CreateToolBar(frame, -y, "CLASS_PALADIN_BUFF", {
         ["bmana"] = {
             icon = "bmana",


### PR DESCRIPTION
These only makes sense for WOTLK.

I'm not sure if each branch is maintained independently, of if I need to segregate it from the other expansions somehow?

Requires https://github.com/celguar/mangosbot-bots/pull/105 to makes sense :)

Icons might need an update - I have no idea what to put there?
Currently, it looks like this:
![image](https://user-images.githubusercontent.com/483707/179614144-e1d1d16b-f71a-4cee-a584-566b47b9e47e.png)

In game (without addons), the Totem bar looks like this:
![image](https://user-images.githubusercontent.com/483707/179614211-e0b73b08-420a-436d-8f3b-8d0909fc9adb.png)