### PR TITLE
3.3.5a fixes

### DIFF
--- a/Mangosbot.lua
+++ b/Mangosbot.lua
@@ -2680,15 +2680,6 @@ function createDropdown(opts)
             info.func = change_func
             UIDropDownMenu_AddButton(info)
         end
-        --[[for key, val in pairs(menu_items) do
-            info.text = val .. "...";
-            info.checked = false
-            info.menuList= key
-            info.hasArrow = false
-            info.justifyH = "LEFT"
-            info.func = change_func
-            UIDropDownMenu_AddButton(info)
-        end--]]
     end, "MENU")
 
     return dropdown
@@ -2727,8 +2718,6 @@ function CreateDropDownMenu(menu_name, menu_title, menu_items, menu_commands, pa
         ['items']=menu_items,
         ['defaultVal']='', 
         ['changeFunc']=function()
-            local id = this:GetID()
-            --SendBotCommand(menu_commands[id], "WHISPER", nil, MenuForBot)
             local editBox = DEFAULT_CHAT_FRAME.editBox--getglobal("ChatFrame1EditBox")
             local id = this:GetID()
             editBox:Show()

--- a/Mangosbot.lua
+++ b/Mangosbot.lua
@@ -2718,7 +2718,7 @@ function CreateDropDownMenu(menu_name, menu_title, menu_items, menu_commands, pa
         ['items']=menu_items,
         ['defaultVal']='', 
         ['changeFunc']=function()
-            local editBox = DEFAULT_CHAT_FRAME.editBox--getglobal("ChatFrame1EditBox")
+            local editBox = getglobal("ChatFrame1EditBox")
             local id = this:GetID()
             editBox:Show()
             editBox:SetFocus()

--- a/Mangosbot.lua
+++ b/Mangosbot.lua
@@ -948,7 +948,7 @@ function CreateSaveManaToolBar(frame, y, name, group, x, spacing, register)
 end
 
 function StartChat()
-    local editBox = getglobal("ChatFrameEditBox")
+    local editBox = getglobal("ChatFrame1EditBox")
     editBox:Show()
     editBox:SetFocus()
     local name = GetUnitName("target")
@@ -2670,7 +2670,17 @@ function createDropdown(opts)
 
     UIDropDownMenu_Initialize(dropdown, function(self, level, _)
         local info = {}
-        for key, val in pairs(menu_items) do
+        for i = 1, table.getn(menu_items) do
+            info = {}
+            info.text = menu_items[i] .. "..."
+            info.checked = false
+            info.menuList= i
+            info.hasArrow = false
+            info.justifyH = "LEFT"
+            info.func = change_func
+            UIDropDownMenu_AddButton(info)
+        end
+        --[[for key, val in pairs(menu_items) do
             info.text = val .. "...";
             info.checked = false
             info.menuList= key
@@ -2678,7 +2688,7 @@ function createDropdown(opts)
             info.justifyH = "LEFT"
             info.func = change_func
             UIDropDownMenu_AddButton(info)
-        end
+        end--]]
     end, "MENU")
 
     return dropdown
@@ -2717,7 +2727,9 @@ function CreateDropDownMenu(menu_name, menu_title, menu_items, menu_commands, pa
         ['items']=menu_items,
         ['defaultVal']='', 
         ['changeFunc']=function()
-            local editBox = getglobal("ChatFrameEditBox")
+            local id = this:GetID()
+            --SendBotCommand(menu_commands[id], "WHISPER", nil, MenuForBot)
+            local editBox = DEFAULT_CHAT_FRAME.editBox--getglobal("ChatFrame1EditBox")
             local id = this:GetID()
             editBox:Show()
             editBox:SetFocus()
@@ -2904,7 +2916,7 @@ Mangosbot_EventFrame:SetScript("OnEvent", function(self)
                 end)
                 whisperBtn["key"] = key
                 whisperBtn:SetScript("OnClick", function()
-                    local editBox = getglobal("ChatFrameEditBox")
+                    local editBox = getglobal("ChatFrame1EditBox")
                     editBox:Show()
                     editBox:SetFocus()
                     editBox:SetText("/whisper " .. whisperBtn["key"] .. " ")
@@ -3400,6 +3412,16 @@ function SlashCmdList.MANGOSBOT(msg, editbox) -- 4.
             SendBotCommand(".bot list", "SAY")
             QueryBotParty()
         end
+    end
+    -- allow show or hide BotRoster independently
+    if (msg == "roster show") then
+        BotRoster.ShowRequest = true
+        SendBotCommand(".bot list", "SAY")
+        QueryBotParty()
+        BotRoster:Show()
+    end
+    if (msg == "roster hide") then
+        BotRoster:Hide()
     end
     if (string.find(msg, "debug")) then
         local cmd = string.sub(msg, 7)


### PR DESCRIPTION
- fix for out of order `menu_items[i]` in dialogs, dictionary wasn't in order of commands when iterating over pairs. The `menu_items[i]` weren't matching corresponding `menu_commands[i]` at the same index
- 3.3.5 uses `ChatFrame1EditorBox`
- `.bot roster show`, `.bot roster hide` command to allow toggling `BotRoster` independently

Tested By:
- Playing the game & utilizing the addon
- verifying menu commands execute accurately based on what is described in the menu items description
- verifying `.bot roster show`, `.bot roster hide` show & hide `BotRoster` menu